### PR TITLE
Warn user if they are committing a file that was recently changed

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -452,6 +452,9 @@ add_files_to_dir = Add files to %s
 unable_to_upload_files = Unable to upload files, an error occurred.
 add_subdir = Add subdirectory…
 name_your_file = Name your file…
+user_has_committed_since_you_started_editing = %s has committed since you started editing.
+see_what_changed = See what changed.
+pressing_commit_again_will_overwrite_those_changes = Pressing '%s' again will overwrite those changes.
 
 commits.commits = Commits
 commits.search = Search commits

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -283,6 +283,7 @@ type EditRepoFileForm struct {
 	CommitMessage  string
 	CommitChoice string `binding:"Required;MaxSize(50)"`
 	NewBranchName string `binding:"AlphaDashDot;MaxSize(100)"`
+	LastCommit string
 }
 
 func (f *EditRepoFileForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {

--- a/templates/base/alert.tmpl
+++ b/templates/base/alert.tmpl
@@ -1,15 +1,15 @@
 {{if .Flash.ErrorMsg}}
 	<div class="ui negative message">
-		<p>{{.Flash.ErrorMsg}}</p>
+		<p>{{.Flash.ErrorMsg | Safe}}</p>
 	</div>
 {{end}}
 {{if .Flash.SuccessMsg}}
 	<div class="ui positive message">
-		<p>{{.Flash.SuccessMsg}}</p>
+		<p>{{.Flash.SuccessMsg | Safe}}</p>
 	</div>
 {{end}}
 {{if .Flash.InfoMsg}}
 	<div class="ui info message">
-		<p>{{.Flash.InfoMsg}}</p>
+		<p>{{.Flash.InfoMsg| Safe}}</p>
 	</div>
 {{end}}

--- a/templates/repo/edit.tmpl
+++ b/templates/repo/edit.tmpl
@@ -6,6 +6,7 @@
 		{{template "base/alert" .}}
 		<form class="ui comment form" action="{{EscapePound $.Link}}" method="post">
 			{{.CsrfTokenHtml}}
+			<input type="hidden" name="last_commit" value="{{.LastCommit}}">
 			<div class="ui secondary menu">
 				<div class="item fitted">
 					<div class="ui breadcrumb field{{if .Err_Filename}} error{{end}}">


### PR DESCRIPTION
```
A user who edits a file and commits changes after another user has edited
at the same time (after the first user opened the editor) they will get
a warning message with who changed it and a link to the changes.

This required changing templates/base/alert.tmpl to allow links
```
