### PR TITLE
Add cancel and increase size of filename form

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -417,6 +417,8 @@ file_view_raw = View Raw
 file_permalink = Permalink
 
 cancel = Cancel
+cancel_lower = cancel
+or = or
 new_file = New file
 upload_files = Upload files
 find_file = Find file

--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -2714,7 +2714,6 @@ footer .ui.language .menu {
 .ui.form .breadcrumb input {
   min-height: 34px;
   padding: 7px 8px;
-  font-size: 13px;
   color: #333;
   vertical-align: middle;
   background-color: #fff;
@@ -2863,4 +2862,9 @@ footer .ui.language .menu {
 }
 #file-buttons {
   padding-right: 15px;
+}
+.ui.breadcrumb.field {
+  margin-bottom: 10px !important;
+  font-size: 1.5em;
+  color: #767676;
 }

--- a/templates/repo/edit.tmpl
+++ b/templates/repo/edit.tmpl
@@ -21,6 +21,7 @@
 								<span class="section"><a href="{{EscapePound $.BranchLink}}/{{EscapePound $v}}">{{$v}}</a></span>
 							{{end}}
 						{{end}}
+						<span class="repo-edit-file-cancel">{{.i18n.Tr "repo.or"}} <a href="{{EscapePound $.BranchLink}}/{{EscapePound $.TreeName}}">{{.i18n.Tr "repo.cancel_lower"}}</a></span>
 						<input type="hidden" id="tree-name" name="tree_name" value="{{.TreeName}}" required>
 					</div>
 				</div>


### PR DESCRIPTION
The filename form on the edit page needed a bit of help...was too small, and no option to cancel the edit quickly.
